### PR TITLE
Add starter notebook for log loading

### DIFF
--- a/driver.ipynb
+++ b/driver.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set global variables\n",
+    "LOG_ROOT = '/path/to/logs'\n",
+    "OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import helper functions\n",
+    "from src import log_loader\n",
+    "# Additional imports can be added here\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load log data\n",
+    "output_log = log_loader.load_output_log(LOG_ROOT)\n",
+    "player_log = log_loader.load_player_log(LOG_ROOT)\n",
+    "\n",
+    "# TODO: assemble prompt from logs and instructions\n",
+    "# TODO: submit the prompt to the language model\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a basic driver notebook with cells for configuration, imports, and log loading

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a8ad7be4832e8b66ef9b4fa52522