### PR TITLE
Add OpenAI completion helper and integrate driver

### DIFF
--- a/driver.ipynb
+++ b/driver.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "# Import helper functions\n",
-    "from src import log_loader\n",
+    "from src import log_loader, complete_prompt\n",
     "# Additional imports can be added here\n"
    ]
   },
@@ -32,8 +32,10 @@
     "output_log = log_loader.load_output_log(LOG_ROOT)\n",
     "player_log = log_loader.load_player_log(LOG_ROOT)\n",
     "\n",
-    "# TODO: assemble prompt from logs and instructions\n",
-    "# TODO: submit the prompt to the language model\n"
+    "# Assemble prompt from logs\n",
+    "prompt = output_log + '\n' + player_log\n",
+    "result = complete_prompt(OPENAI_API_KEY, prompt)\n",
+    "print(result)\n"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=7.0
+openai>=1.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+from .log_loader import load_log, load_output_log, load_player_log
+from .openai_helper import complete_prompt
+
+__all__ = [
+    "load_log",
+    "load_output_log",
+    "load_player_log",
+    "complete_prompt",
+]
+

--- a/src/openai_helper.py
+++ b/src/openai_helper.py
@@ -1,0 +1,24 @@
+import openai
+
+
+def complete_prompt(api_key: str, prompt: str, model: str = "text-davinci-003") -> str:
+    """Submit a prompt to the OpenAI completions API and return the response text.
+
+    Parameters
+    ----------
+    api_key : str
+        OpenAI API key to authenticate the request.
+    prompt : str
+        Text prompt to send to the API.
+    model : str, optional
+        Model name to use for completion, by default ``text-davinci-003``.
+
+    Returns
+    -------
+    str
+        The text of the completion response.
+    """
+    openai.api_key = api_key
+    response = openai.Completion.create(model=model, prompt=prompt)
+    return response.choices[0].text.strip()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_openai_helper.py
+++ b/tests/test_openai_helper.py
@@ -1,0 +1,25 @@
+import types
+
+import src.openai_helper as openai_helper
+
+
+class DummyResponse:
+    def __init__(self, text):
+        self.choices = [types.SimpleNamespace(text=text)]
+
+
+def test_complete_prompt(monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return DummyResponse("result text")
+
+    monkeypatch.setattr(openai_helper.openai.Completion, "create", fake_create)
+
+    text = openai_helper.complete_prompt("key", "hello")
+
+    assert text == "result text"
+    assert captured["model"] == "text-davinci-003"
+    assert captured["prompt"] == "hello"
+


### PR DESCRIPTION
## Summary
- add `complete_prompt` helper to submit prompts to OpenAI
- expose helper via `src` package
- import and invoke helper in `driver.ipynb`
- add tests for the helper and pytest configuration
- require `openai` in dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869aa541458832ea184adfee10817cc