### PR TITLE
Add configurable OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ player = log_loader.load_player_log('/path/to/RimWorld_data')
 
 Any log path can be supplied to `load_log()` if you need to load custom files.
 
+## Choosing the OpenAI Model
+
+The helper function ``complete_prompt`` accepts a ``model`` parameter so you can
+control which OpenAI model generates the story. It defaults to ``gpt-4.1`` but
+can be overridden if you wish to use a different engine:
+
+```python
+from src import complete_prompt
+
+text = complete_prompt("your-api-key", "Once upon a time...", model="gpt-3.5")
+```
+
 ## Project Status
 
 This is an early prototype intended to explore approaches for generating longer

--- a/src/openai_helper.py
+++ b/src/openai_helper.py
@@ -1,7 +1,7 @@
 import openai
 
 
-def complete_prompt(api_key: str, prompt: str, model: str = "text-davinci-003") -> str:
+def complete_prompt(api_key: str, prompt: str, model: str = "gpt-4.1") -> str:
     """Submit a prompt to the OpenAI completions API and return the response text.
 
     Parameters
@@ -11,7 +11,7 @@ def complete_prompt(api_key: str, prompt: str, model: str = "text-davinci-003") 
     prompt : str
         Text prompt to send to the API.
     model : str, optional
-        Model name to use for completion, by default ``text-davinci-003``.
+        Model name to use for completion, by default ``gpt-4.1``.
 
     Returns
     -------

--- a/tests/test_openai_helper.py
+++ b/tests/test_openai_helper.py
@@ -20,6 +20,22 @@ def test_complete_prompt(monkeypatch):
     text = openai_helper.complete_prompt("key", "hello")
 
     assert text == "result text"
-    assert captured["model"] == "text-davinci-003"
+    assert captured["model"] == "gpt-4.1"
     assert captured["prompt"] == "hello"
+
+
+def test_complete_prompt_custom_model(monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return DummyResponse("alt")
+
+    monkeypatch.setattr(openai_helper.openai.Completion, "create", fake_create)
+
+    text = openai_helper.complete_prompt("key", "hi", model="gpt-3.5")
+
+    assert text == "alt"
+    assert captured["model"] == "gpt-3.5"
+    assert captured["prompt"] == "hi"
 


### PR DESCRIPTION
## Summary
- allow specifying the OpenAI model when generating completions
- default to `gpt-4.1`
- document model selection in README
- test default and custom model usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869aecc129c832eac836996bec2e1d4